### PR TITLE
Update amorphouspy GitHub URLs

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -15,7 +15,7 @@ Research interests: My research interests lie at the intersection of materials s
 
 
 
-I contribute open-source tools to the atomistic simulation community. [**atomex**](https://github.com/Atilaac/atomex) is a Python package I develop and maintain for analyzing MD simulation. [**amorphouspy**]() is a framework I lead for end-to-end computational glass science workflows — from structure generation and melt-quench simulations to property calculation — developed in collaboration with Schott AG and the Max-Planck-Institute for Sustainable Material. More details on the [Software](/portfolio/) page.
+I contribute open-source tools to the atomistic simulation community. [**atomex**](https://github.com/Atilaac/atomex) is a Python package I develop and maintain for analyzing MD simulation. [**amorphouspy**](https://github.com/glasagent/amorphouspy) is a framework I lead for end-to-end computational glass science workflows — from structure generation and melt-quench simulations to property calculation — developed in collaboration with Schott AG and the Max-Planck-Institute for Sustainable Material. More details on the [Software](/portfolio/) page.
 
 You can check my [GitHub](https://github.com/Atilaac) for code I wrote or currently working on and [Google scholar](https://scholar.google.com/citations?user=TTAujLUAAAAJ&hl=en) for my full list of papers.
 

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -42,7 +42,7 @@ Work experience
 Software
 ======
 * [**atomex**](https://github.com/Atilaac/atomex) — Python package for analyzing atomistic simulation and experimental data. Features include radial distribution functions, vibrational density of states, ring statistics, persistent homology, and coordination analysis. Sole developer and maintainer. `pip install atomex`
-* [**amorphouspy**](https://github.com/achrafatila/amorphouspy) — End-to-end workflows for computational glass science, covering structure generation, melt-quench simulations with LAMMPS, and property calculation (elastic moduli, viscosity, CTE). Lead developer; collaboration with BAM, Schott AG, and MPIE.
+* [**amorphouspy**](https://github.com/glasagent/amorphouspy) — End-to-end workflows for computational glass science, covering structure generation, melt-quench simulations with LAMMPS, and property calculation (elastic moduli, viscosity, CTE). Lead developer; collaboration with BAM, Schott AG, and MPIE.
 
 Publications
 ======

--- a/_portfolio/portfolio-2.md
+++ b/_portfolio/portfolio-2.md
@@ -28,7 +28,7 @@ collection: portfolio
 
 ```bash
 curl -fsSL https://pixi.sh/install.sh | bash  # install pixi
-git clone https://github.com/achrafatila/amorphouspy.git
+git clone https://github.com/glasagent/amorphouspy.git
 cd amorphouspy && pixi install
 ```
 


### PR DESCRIPTION
Standardize the amorphouspy repository URL to https://github.com/glasagent/amorphouspy across the site. Replaced the empty/broken and old achrafatila links in _pages/about.md, _pages/cv.md, and the git clone command in _portfolio/portfolio-2.md so pages and instructions point to the correct repo.