### PR TITLE
Add publication section jump links and updates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,10 +48,14 @@ author:
 
 # Publication Category - The following the list of publication categories and their headings
 publication_category:
+  manuscripts:
+    title: 'Journal Articles'
+  preprints:
+    title: 'Preprints & Under Review'
+  theses:
+    title: 'Thesis'
   books:
     title: 'Books'
-  manuscripts:
-    title: 'Journal Articles'    
   conferences:
     title: 'Conference Papers'
 

--- a/_pages/publications.html
+++ b/_pages/publications.html
@@ -26,7 +26,21 @@ author_profile: true
     {% assign cat_posts = site.publications | where: "category", category[0] | sort: "date" %}
     {% assign cat_total = cat_posts | size %}
     {% if cat_total == 0 %}{% continue %}{% endif %}
-    <div class="pub-category-heading"><h2>{{ category[1].title }}</h2></div>
+    {% comment %} Quick-jump shortcuts to the other (non-empty) sections {% endcomment %}
+    {% capture jump_links %}
+      {% for other in site.publication_category %}
+        {% if other[0] != category[0] %}
+          {% assign other_posts = site.publications | where: "category", other[0] %}
+          {% if other_posts.size > 0 %}<a class="pub-shortcut" href="#{{ other[0] | slugify }}">{{ other[1].title }}</a>{% endif %}
+        {% endif %}
+      {% endfor %}
+    {% endcapture %}
+    {% if jump_links contains "pub-shortcut" %}
+    <nav class="pub-shortcuts" aria-label="Jump to other publication sections">
+      <span class="pub-shortcuts__label">Jump to:</span>{{ jump_links }}
+    </nav>
+    {% endif %}
+    <div class="pub-category-heading" id="{{ category[0] | slugify }}"><h2>{{ category[1].title }}</h2></div>
     {% for post in cat_posts reversed %}
       {% assign pub_number = forloop.rindex %}
       <div style="display:flex;align-items:flex-start;gap:0.75rem;">

--- a/_publications/pub_016.md
+++ b/_publications/pub_016.md
@@ -1,7 +1,7 @@
 ---
 title: "Influence of Structure and Topology on the Deformation Behavior and Fracture of Oxide Glasses"
 collection: publications
-category: manuscripts
+category: theses
 permalink: "/publication/pub-016"
 excerpt: "Doctoral thesis using large-scale atomistic simulations to uncover how modifier type, network topology, and pre-deformation history control deformation-induced structural anisotropy and fracture in metaphosphate and silicate oxide glasses."
 date: 2023-02-22

--- a/_publications/pub_026.md
+++ b/_publications/pub_026.md
@@ -1,9 +1,9 @@
 ---
-title: "On the presence of nanoscale heterogeneity in Ni₁₅Co₁₅Al₇₀ metallic glass under pressure"
+title: "On the presence of nanoscale heterogeneity in Al₇₀Ni₁₅Co₁₅ metallic glass under pressure"
 collection: publications
 category: manuscripts
 permalink: "/publication/pub-026"
-excerpt: "MD simulations reveal that Ni₁₅Co₁₅Al₇₀ metallic glass exhibits nanoscale structural heterogeneity that evolves with applied pressure, with icosahedral-like clusters playing a key role in the pressure-dependent structural changes."
+excerpt: "MD simulations reveal that Al₇₀Ni₁₅Co₁₅ metallic glass exhibits nanoscale structural heterogeneity that evolves with applied pressure, with icosahedral-like clusters playing a key role in the pressure-dependent structural changes."
 date: 2020-01-01
 venue: "Journal of Non-Crystalline Solids"
 paperurl: "https://doi.org/10.1016/j.jnoncrysol.2020.120381"
@@ -17,4 +17,4 @@ lay_summary_de: "Metallische Gläser sind faszinierende Materialien, die für ih
 ---
 
 ## Abstract
-Metallic glasses exhibit structural heterogeneity at the nanoscale, which influences their mechanical and physical properties. Using molecular dynamics simulations, we investigate the structural heterogeneity and its pressure dependence in Ni₁₅Co₁₅Al₇₀ metallic glass. The results show nanoscale compositional and structural fluctuations that evolve under applied pressure. Icosahedral-like clusters are identified as key structural motifs whose concentration and distribution change with pressure. These findings provide insights into the pressure-driven structural evolution of metallic glasses and its relationship to their properties.
+Metallic glasses exhibit structural heterogeneity at the nanoscale, which influences their mechanical and physical properties. Using molecular dynamics simulations, we investigate the structural heterogeneity and its pressure dependence in Al₇₀Ni₁₅Co₁₅ metallic glass. The results show nanoscale compositional and structural fluctuations that evolve under applied pressure. Icosahedral-like clusters are identified as key structural motifs whose concentration and distribution change with pressure. These findings provide insights into the pressure-driven structural evolution of metallic glasses and its relationship to their properties.

--- a/_publications/pub_028.md
+++ b/_publications/pub_028.md
@@ -1,7 +1,7 @@
 ---
 title: "Competing Bond Dynamics Govern the Brittle-to-Ductile Transition in Amorphous Silica under Compression"
 collection: publications
-category: manuscripts
+category: preprints
 permalink: "/publication/pub-028"
 excerpt: "Molecular dynamics study revealing how competing bond dynamics control the brittle-to-ductile transition in amorphous silica under compressive loading."
 date: 2026-04-01

--- a/_publications/pub_029.md
+++ b/_publications/pub_029.md
@@ -1,7 +1,7 @@
 ---
 title: "Defect-like Packing and Structural Disorder in Monoatomic Metallic Glasses"
 collection: publications
-category: manuscripts
+category: preprints
 permalink: "/publication/pub-029"
 excerpt: "Investigation of defect-like packing motifs and structural disorder in monoatomic metallic glasses using atomistic simulations."
 date: 2026-05-01

--- a/_publications/pub_030.md
+++ b/_publications/pub_030.md
@@ -1,7 +1,7 @@
 ---
 title: "Icosahedral short-range order suppresses thermal expansion in metallic glasses"
 collection: publications
-category: manuscripts
+category: preprints
 permalink: "/publication/pub-030"
 excerpt: "Atomistic simulations demonstrating that icosahedral short-range order is responsible for suppressing thermal expansion in metallic glasses."
 date: 2026-01-01

--- a/_publications/pub_031.md
+++ b/_publications/pub_031.md
@@ -1,7 +1,7 @@
 ---
 title: "Microstructure-specific mechanisms define multistage relaxation dynamics in a metallic model-glass"
 collection: publications
-category: manuscripts
+category: preprints
 permalink: "/publication/pub-031"
 excerpt: "Study linking microstructure-specific mechanisms to multistage relaxation dynamics in a metallic model-glass system."
 date: 2025-07-01

--- a/_publications/pub_032.md
+++ b/_publications/pub_032.md
@@ -1,7 +1,7 @@
 ---
 title: "Supporting AI Readiness through Digital Workflows in Materials Science"
 collection: publications
-category: manuscripts
+category: preprints
 permalink: "/publication/pub-032"
 date: 2026-06-03
 venue: "Submitted"

--- a/_publications/pub_033.md
+++ b/_publications/pub_033.md
@@ -1,0 +1,16 @@
+---
+title: "Atomic structure and modifiers clustering in silicate glasses: Effect of modifier cations"
+collection: publications
+category: preprints
+permalink: "/publication/pub-033"
+excerpt: "Molecular dynamics simulations show that the tendency of modifier–modifier clustering in silicate glasses scales with the modifier cation size and the modifier–oxygen bond strength, governing the short- and medium-range structure and opening a route to tune glass properties through the choice of modifier cation."
+date: 2020-07-17
+venue: "arXiv"
+paperurl: "https://arxiv.org/abs/2007.09247"
+citation: "Achraf Atila. \"Atomic structure and modifiers clustering in silicate glasses: Effect of modifier cations.\" <i>arXiv preprint arXiv:2007.09247</i> (2020)."
+corresponding: true
+lay_summary_en: "Oxide glasses are built from a rigid network of glass-former polyhedra together with 'modifier' cations that either balance charge or break up the network. While the influence of how much modifier is added is fairly well understood, the effect of which modifier is used on how those cations cluster together — and on the glass's tendency to phase-separate — has been far less clear. Using molecular dynamics simulations, this study compares a series of silicate glasses containing different modifier cations and shows that the tendency of modifiers to cluster with one another is controlled by the size of the modifier cation and the strength of the modifier–oxygen bond. The work also traces how different modifiers reshape the glass at the short and medium range, giving a clearer picture of how the choice of cation can be used to develop and optimize glass properties."
+---
+
+## Abstract
+Oxide glasses are made of a network of glass former polyhedra, and modifiers which have a role in neutralizing the charge of the glass former polyhedra or depolymerize the glass network. The effect of the modifier content on the structure and properties of the glass are to some extent, well known. However, the effect of the type of modifiers on the clustering and the tendency to form a phase separation in the glass is not investigated in detail and still not fully understood until now. Here, we use molecular dynamics to investigate the effect of the modifier type on the structure and the clustering tendency of a series of modified silicate glasses. Specifically, we show that the tendency of modifier–modifier cluster formation is linked to the modifier size and modifier–oxygen bond strength. The effect of different modifiers on the short- and medium-range structure of the glass is also discussed. This allows us to get an overview of the effect of cations nature on the properties of the glass and opens a new window for further development and optimization of the glass properties.

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -540,6 +540,34 @@ html[data-theme="dark"] .badge--submitted {
 }
 html[data-theme="dark"] .scholar-metrics { background: var(--bg-secondary); }
 
+/* Quick-jump shortcuts to publication sections */
+.pub-shortcuts {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 1.5rem;
+  font-size: 0.85rem;
+}
+.pub-shortcuts__label {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+.pub-shortcut {
+  display: inline-block;
+  padding: 0.25rem 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  text-decoration: none;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+.pub-shortcut:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 /* Category section headings */
 .pub-category-heading {
   background: var(--bg-secondary);
@@ -547,6 +575,7 @@ html[data-theme="dark"] .scholar-metrics { background: var(--bg-secondary); }
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
   padding: 0.5rem 1rem;
   margin: 2rem 0 1rem;
+  scroll-margin-top: 5rem;
 }
 .pub-category-heading h2 {
   margin: 0;


### PR DESCRIPTION
Add quick-jump navigation for non-empty publication categories (HTML + CSS) and anchor headings so users can jump between sections. Reclassify several publications from "manuscripts" to "preprints" (pub_028–pub_032) and move pub_016 to "theses". Add new preprint entry pub_033.md and correct composition/name references and excerpt/abstract in pub_026. Minor reorder/cleanup of publication_category in _config.yml to ensure the manuscripts category is defined in the intended place.